### PR TITLE
Move TypeScript into devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,10 @@
     "babel-loader": "^8.0.5",
     "css-loader": "^0.28.11",
     "mini-css-extract-plugin": "^0.4.5",
+    "ts-loader": "^5.4.3",
+    "typescript": "^3.4.5",
     "webpack": "^4.28.3",
     "webpack-cli": "^3.2.0",
     "webpack-dev-server": "^3.1.14"
-  },
-  "dependencies": {
-    "ts-loader": "^5.4.3",
-    "typescript": "^3.4.5"
   }
 }


### PR DESCRIPTION
This moves TypeScript to a development dependency since it isn't needed to import js/css files directly.

**Note:** I didn't include `package-lock.json` since I have a different version of npm. I suggest running `npm install` and adding the package lock changes from this PR.

Closes #47.